### PR TITLE
whitelist default-src > data.pendo.io

### DIFF
--- a/background.js
+++ b/background.js
@@ -93,6 +93,7 @@ var requiredHeaders = [
     { dir: "img-src", src: "app.pendo.io" },
     { dir: "img-src", src: "adopt.pendo.io" },
     { dir: "img-src", src: `*.storage.googleapis.com` },
+    { dir: "default-src", src: "data.pendo.io" },
     { dir: "connect-src", src: "'self'" },
     { dir: "connect-src", src: "app.pendo.io" },
     { dir: "connect-src", src: "adopt.pendo.io" },


### PR DESCRIPTION
The latest JS lib is trying to load a gif from data.pendo.io via the a `default-src` attribute.